### PR TITLE
executeWatchdogAfter returns NaN

### DIFF
--- a/class-process-watchdog.js
+++ b/class-process-watchdog.js
@@ -108,7 +108,8 @@ class ProcessWatchdog {
 
             // Calculate time, when to execute the webserver check.
             const processUptime = (new Date().getTime()) - processDescription.pm2_env.created_at;
-            const executeWatchdogAfter = Math.max(processDescription.pm2_env.min_uptime - processUptime, parseInt(this.options.checkingInterval), 1000);
+            const minUptime = typeof(processDescription.pm2_env.min_uptime) !== 'undefined' ? processDescription.pm2_env.min_uptime : 1000;
+            const executeWatchdogAfter = Math.max(minUptime - processUptime, parseInt(this.options.checkingInterval), 1000);
             console.trace(`Process ${this.name} - next checking after ${(executeWatchdogAfter/1000).toFixed(0)}s`);
 
             // Plan the next execution


### PR DESCRIPTION
executeWatchdogAfter returns NaN causing the execution to not wait for the checkingInterval

processDescription.pm2_env.min_uptime can be 'undefined' wich causes the `minUptime - processUptime` to become NaN and thus it seems this value is used with Math.max